### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/03_signal.t
+++ b/t/03_signal.t
@@ -31,7 +31,7 @@ if ($^O ne 'VMS') {
                 unless $perl_path =~ m/$Config{_exe}$/i;
 }
 
-use_ok("MooX::Ipc::Cmd","run");
+use_ok("MooX::Ipc::Cmd");
 
 chdir("t");
 


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.